### PR TITLE
Access keys

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1,0 +1,53 @@
+export const text = {
+  ButtonAlt: {
+    play: 'Listen to the page',
+    pause: '',
+    stop: 'Stop reading',
+    speed: 'Change the reading speed',
+    settings: 'Settings button',
+    closeSettings: 'Button to close the settings window',
+  },
+  ButtonTitle: {
+    ear: 'Listen',
+    play: 'Play',
+    pause: 'Pause',
+    stop: 'Stop',
+    speed: 'Change speed',
+    settings: 'Settings',
+    closeSettings: 'Close settings',
+  },
+  settingsModuleText: {
+    userText: {
+      mainHead: 'Settings',
+      sections: [
+        {
+          sectionHead: 'What is a web reader?',
+          sectionParagraphs: [
+            'Web readers are tools used to read text on a website.'+
+              'Listening to a webpage is as easy as pressing the play button!',
+            'This web reader, WebRICE, was developed at Reykjavik University'+
+              ' as a part of the Language Technology Programme for Icelandic ' +
+              ' 2019-2023.',
+          ],
+        },
+        {
+          sectionHead: 'Navigate with the keyboard',
+          sectionParagraphs: [
+            'The web reader can be used in two ways with the keyboard. The ' +
+              'first is by using Tab to navigate and Enter to select. ' +
+              'The second way is by using the access keys',
+            'Play and pause: Modifier + L',
+            'Stop reading: Modifier + x',
+            'Stop and close Settings: Modifier + 1',
+          ],
+        },
+      ],
+      submit: 'Save settings',
+    },
+  },
+};
+
+/*
+export interface langText {
+
+}*/

--- a/src/lang/is.ts
+++ b/src/lang/is.ts
@@ -19,11 +19,27 @@ export const text = {
   settingsModuleText: {
     userText: {
       mainHead: 'Stillingar',
-      whatIsHead: 'Hvað er veflesari?',
-      whatIsPhara1: 'Veflesari er tól sem les upp texta á vefsíðu.'+
-      ' Nóg er að ýta á spilunar takkann og lesturinn hefst!',
-      whatIsPhara2: ' Þessi veflesari var þróaður af Háskólanum í Reykjavík'+
-      ' sem hluti af máltækni áætlun.',
+      sections: [
+        {
+          sectionHead: 'Hvað er veflesari?',
+          sectionParagraphs: [
+            'Veflesari er tól sem les upp texta á vefsíðu.'+
+              ' Nóg er að ýta á afspilunartakkann og lesturinn hefst!',
+            ' Þessi veflesari var þróaður af Háskólanum í Reykjavík'+
+              ' sem hluti af máltækniáætlun.',
+          ],
+        },
+        {
+          sectionHead: 'Nota lyklaborð',
+          sectionParagraphs: [
+            'Það er hægt að nota Tab og Enter til að stýra veflesaranum. ' +
+              'Það er líka hægt að nota aðgangslykla.',
+            'Spila og pása: Breytihnappur + L',
+            'Stoppa lestur: Breytihnappur + x',
+            'Opna stillingar: Breytihnappur + 1',
+          ],
+        },
+      ],
       submit: 'Vista stillingar',
     },
   },

--- a/src/modules/PlayPauseButton.ts
+++ b/src/modules/PlayPauseButton.ts
@@ -84,6 +84,7 @@ export class PlayPauseButton extends MainButton {
    */
   protected additionalHTML(button: HTMLDivElement): void {
     button.classList.add('webriceMainButton');
+    button.setAttribute('accesskey', 'L');
     button.appendChild(this.secondButtonIcon.svg);
     button.appendChild(this.buttonIcon.svg);
   }

--- a/src/modules/SettingsButton.ts
+++ b/src/modules/SettingsButton.ts
@@ -1,6 +1,6 @@
 import {MainButton} from './MainButton';
 import {Icon} from './icons';
-// Functionality for other languages is needed
+// TODO: Functionality for other languages is needed
 import {text} from './../lang/is';
 import {CloseIcon} from './icons';
 import {ImageButton} from './ImageButton';
@@ -108,22 +108,26 @@ export class SettingsButton extends MainButton {
         document.createTextNode(this.helpText.userText.mainHead));
     parent.appendChild(settingsMainHeading);
 
-    const aboutHead = document.createElement('h3');
-    const headingText = document.createTextNode(
-        this.helpText.userText.whatIsHead);
-    aboutHead.appendChild(headingText);
-    parent.appendChild(aboutHead);
+    const sections = this.helpText.userText.sections;
+    let sectNum;
+    for (sectNum = 0; sectNum < sections.length; sectNum++) {
+      const sectionHead = document.createElement('h3');
+      const headingText = document.createTextNode(
+          sections[sectNum].sectionHead);
+      sectionHead.appendChild(headingText);
+      parent.appendChild(sectionHead);
 
-    let paragraph = document.createElement('p');
-    let aboutNode = document.createTextNode(
-        this.helpText.userText.whatIsPhara1);
-    paragraph.appendChild(aboutNode);
-    parent.appendChild(paragraph);
-
-    paragraph = document.createElement('p');
-    aboutNode = document.createTextNode(this.helpText.userText.whatIsPhara2);
-    paragraph.appendChild(aboutNode);
-    parent.appendChild(paragraph);
+      const sectionParagraphs = sections[sectNum].sectionParagraphs;
+      let paragraphNum;
+      for (paragraphNum = 0; paragraphNum < sectionParagraphs.length;
+        paragraphNum++) {
+        const sectionParagraph = document.createElement('p');
+        const paragraphText = document.createTextNode(
+            sectionParagraphs[paragraphNum]);
+        sectionParagraph.appendChild(paragraphText);
+        parent.appendChild(sectionParagraph);
+      }
+    }
   }
 
   /**

--- a/src/modules/SettingsButton.ts
+++ b/src/modules/SettingsButton.ts
@@ -34,6 +34,18 @@ export class SettingsButton extends MainButton {
   }
 
   /**
+   * Adds to the button html
+   * without the neccesary base being affected.
+   * Add an access key - 1
+   * @param {HTMLDivElement} button
+   */
+  protected additionalHTML(button: HTMLDivElement): void {
+    button.classList.add('webriceMainButton');
+    button.setAttribute('accesskey', '1');
+    button.appendChild(this.buttonIcon.svg);
+  }
+
+  /**
    * @return {object} object of settings module text
    */
   private get moduleText() {

--- a/src/modules/StopButton.ts
+++ b/src/modules/StopButton.ts
@@ -20,6 +20,18 @@ export class StopButton extends MainButton {
   }
 
   /**
+   * Adds to the button html
+   * without the neccesary base being affected.
+   * Add an access key - x
+   * @param {HTMLDivElement} button
+   */
+  protected additionalHTML(button: HTMLDivElement): void {
+    button.classList.add('webriceMainButton');
+    button.setAttribute('accesskey', 'x');
+    button.appendChild(this.buttonIcon.svg);
+  }
+
+  /**
    * Stop workflow
    * @param {HTMLAudioElement} player - the reference to the webrice audio
    *   player


### PR DESCRIPTION
Add accesskeys (what shows up in Firefox developer tools accessibility as keyboardshortcuts) for main playpause button, stop button, and settings button. These match very closely to the access keys of the leading web reading solution in Iceland.

This also solves the problem of focusing on the webrice div so that people can tab through it.

Also add instructions on how to use the keyboard in the Settings module. I had someone proofread the icelandic version.
Translate the text to English.

Do note that this merges into the mod_keys branch, not the master branch.