### PR TITLE
Fix bug duplicate text + CNAME

### DIFF
--- a/build/CNAME
+++ b/build/CNAME
@@ -1,0 +1,1 @@
+www.webrice.is

--- a/src/Reader.ts
+++ b/src/Reader.ts
@@ -61,22 +61,26 @@ export class Reader {
    * accessed later.
    */
   private setWebText(): void {
-    const webriceTextNode = document.getElementById(this.TEXT_CONTENT_ID);
     try {
-      if (webriceTextNode) {
-        let text = '';
-        // Go through content and extracts text content from html children nodes
-        for (let i = 0; i < webriceTextNode.children.length; i++) {
-          text += webriceTextNode.children[i].textContent + '. ';
-          // TODO: figure out how to indicate the text is from different
-          // nodes/tags to the TTS API so it doesn't read a header and a
-          // paragraph together. Currently using a period to indicate
-          // completion.
+      const webriceTextNode = document.getElementById(this.TEXT_CONTENT_ID);
+      let text = '';
+      // Go through content and extract text content from children
+      const children = webriceTextNode!.childNodes;
+      for (let i = 0; i < children.length; i++) {
+        if (children[i].nodeType === Node.ELEMENT_NODE &&
+          children[i].textContent!.trim()) {
+          text += children[i].textContent + '. ';
+        } else if (children[i].nodeType === Node.TEXT_NODE &&
+          children[i].nodeValue!.trim() ) {
+          text += children[i].nodeValue + '. ';
         }
-        text += webriceTextNode.textContent + '. ';
-        // TODO: extracts alt text for images and links
-        this.webText = text;
+        // TODO: figure out how to indicate the text is from different
+        // nodes/tags to the TTS API so it doesn't read a header and a
+        // paragraph together. Currently using a period to indicate
+        // completion.
       }
+      // TODO: extracts alt text for images and links
+      this.webText = text;
     } catch (e) {
       // Throw a warning because there's nothing to read
       console.warn(this.TEXT_CONTENT_ID + ': Text container id undefined.' +


### PR DESCRIPTION
While trying to make it possible for WebRICE to detect if a text container is empty and to extract text from the text container directly, it caused duplicate text extraction in our demo pages. (18e1b29)

So this PR attempts to make all three possiblle: 
1. remove duplicate text for more complex text containers, 
2. detect when a text container is empty, 
3. and to extract text directly within the text container.

Add CNAME so the website can be found at www.webrice.is