### PR TITLE
Display settings module intuitively

### DIFF
--- a/build/WebRICE_styles.css
+++ b/build/WebRICE_styles.css
@@ -140,7 +140,7 @@
 }
 
 #settingsContainer {
-  overflow-y: scroll;
+  overflow-y: auto;
   color: var(--secondary-color-one);
   margin: 0.2rem 0.2rem 0 0.2rem;
 }

--- a/build/WebRICE_styles.css
+++ b/build/WebRICE_styles.css
@@ -59,6 +59,35 @@
   }
 }
 
+@media (min-width: 200px) {
+  #webriceMainSettingsContainer {
+    left: 0;
+    right: 0;
+    top: 10%;
+    bottom: 0;
+  }
+}
+
+@media (min-width: 800px) {
+  #webriceMainSettingsContainer {
+    width: max-content;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  #webriceOverlay {
+    background-color: var(--secondary-color-one);
+    display: var(--module-visibility);
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    top: 0;
+    opacity: 0.7;
+  }
+}
+
 /* Buttons */
 .webriceMainButton {
   background: var(--main-background);
@@ -106,16 +135,14 @@
   display: var(--module-visibility);
   flex-direction: column;
   margin: 0.15rem 0 0 0;
-  position: absolute;
+  position: fixed;
   background-color: var(--main-color-two);
-  max-width: 13rem;
 }
 
 #settingsContainer {
   overflow-y: scroll;
   color: var(--secondary-color-one);
   margin: 0.2rem 0.2rem 0 0.2rem;
-  max-height: 10rem;
 }
 
 #settingsContainer > h2 {
@@ -151,7 +178,7 @@
 /**
  * Speed styles
  */
-.webriceSpeedButtonGroup {
+.webriceButtonGroup {
   position: relative;
 }
 

--- a/src/modules/SettingsButton.ts
+++ b/src/modules/SettingsButton.ts
@@ -18,6 +18,7 @@ export class SettingsButton extends MainButton {
     header: 'settingsHeader',
     maincontainer: 'webriceMainSettingsContainer',
     container: 'settingsContainer',
+    overlay: 'webriceOverlay',
   }
   /**
    * @param {Icon} icon - icon on button
@@ -135,6 +136,9 @@ export class SettingsButton extends MainButton {
    * @param {HTMLElement} parent - parent element of module
    */
   public createSettingsModule(parent: HTMLElement): void {
+    const settingsOverlay = document.createElement('div');
+    settingsOverlay.setAttribute('id', this.moduleIds.overlay);
+    parent.appendChild(settingsOverlay);
     const settingsContainer = document.createElement('div');
     settingsContainer.setAttribute('id', this.moduleIds.container);
 

--- a/src/modules/SpeedButton.ts
+++ b/src/modules/SpeedButton.ts
@@ -205,7 +205,7 @@ export class SpeedButton extends MainButton {
       this.initializePlayback().then(() => {
         // Then we create the HTML
         button.setAttribute('aria-expanded', 'false');
-        button.classList.add('webriceSpeedButtonGroup');
+        button.classList.add('webriceButtonGroup');
         button.classList.add('webriceMainButton');
         button.classList.add(this.speedElementClass);
         this.buttonIcon.svg.classList.add(this.speedElementClass);


### PR DESCRIPTION
If the page's content is centered like webrice.is's landing page then the settings module does not appear in a logical spot. These changes fix the problem and displays a new solution for smaller screens.

On smaller screens, take up basically the whole page.
On large screens, display in middle of screen with the rest blurred.